### PR TITLE
Use bash for seed data script

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,7 @@ ENV AGENT_HOME=/opt/agent \
 WORKDIR ${AGENT_HOME}
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends git ca-certificates curl \
+    && apt-get install -y --no-install-recommends git ca-certificates curl bash \
     && rm -rf /var/lib/apt/lists/*
 
 COPY scripts ${AGENT_HOME}/scripts

--- a/scripts/seed_data.sh
+++ b/scripts/seed_data.sh
@@ -1,5 +1,5 @@
-#!/bin/sh
-set -eu
+#!/usr/bin/env bash
+set -euo pipefail
 
 echo "Generating non-production seed data..."
 mkdir -p /workspaces/source/tmp


### PR DESCRIPTION
## Summary
- run the seed data script with bash semantics, including pipefail safety
- install bash in the container image so the seed script can execute reliably

## Testing
- docker build --no-cache -t ai-agent-toolkit:latest -f docker/Dockerfile . *(fails: docker: command not found in CI container)*

------
https://chatgpt.com/codex/tasks/task_e_68d3e1ec099c8327b2c8511d2cb8039a